### PR TITLE
Generate mental health summary with LLM

### DIFF
--- a/Project Mental Health/src/conversation_engine.py
+++ b/Project Mental Health/src/conversation_engine.py
@@ -1,6 +1,7 @@
 import os
 import json
 from datetime import datetime
+import re
 import streamlit as st
 from llama_index.core import load_index_from_storage
 from llama_index.core import StorageContext
@@ -38,12 +39,12 @@ def display_messages(chat_store, container, key):
                     st.markdown(message.content)
 
 def save_score(score, content, total_guess, username):
-        """Write score and content to a file.
+        """Write score and content to a file in a robust JSON list format and return the saved entry.
 
         Args:
             score (string): Score of the user's mental health.
             content (string): Content of the user's mental health.
-            total_guess (string): Total guess of the user's mental health.
+            total_guess (int|str): Total guess of the user's mental health.
         """
         current_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
         new_entry = {
@@ -51,16 +52,98 @@ def save_score(score, content, total_guess, username):
             "Time": current_time,
             "Score": score,
             "Content": content,
-            "Total guess": total_guess
+            "Total guess": int(total_guess) if str(total_guess).isdigit() else total_guess,
         }
-        try:
-            with open(SCORES_FILE, "r") as f:
-                  data = json.load(f)
-        except  FileNotFoundError:
-             data = []
+        data = []
+        if os.path.exists(SCORES_FILE) and os.path.getsize(SCORES_FILE) > 0:
+            try:
+                with open(SCORES_FILE, "r", encoding="utf-8") as f:
+                    existing = json.load(f)
+                if isinstance(existing, list):
+                    data = existing
+                elif isinstance(existing, dict):
+                    data = [existing]
+                else:
+                    data = []
+            except json.JSONDecodeError:
+                # Fallback: try to read as JSON Lines (one JSON object per line)
+                try:
+                    with open(SCORES_FILE, "r", encoding="utf-8") as f:
+                        lines = [json.loads(line) for line in f if line.strip()]
+                    data = lines
+                except Exception:
+                    data = []
         data.append(new_entry)
-        with open(SCORES_FILE, "w") as f:
-            json.dump(data, f, indent=4)
+        with open(SCORES_FILE, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=4, ensure_ascii=False)
+        return new_entry
+
+# Helpers to normalize and extract structured values from LLM output
+
+def _normalize_score_label(raw_score: str) -> str:
+    s = str(raw_score or "").strip().lower()
+    if not s:
+        return "Average"
+    bad_synonyms = {"bad", "poor", "low", "worse", "severe", "critical"}
+    good_synonyms = {"good", "very good", "excellent", "strong", "healthy"}
+    quite_good_synonyms = {"quite good", "fairly good", "okay", "ok", "improving", "better", "fair"}
+    average_synonyms = {"average", "moderate", "neutral", "medium"}
+    if s in bad_synonyms:
+        return "Bad"
+    if s in good_synonyms:
+        return "Good"
+    if s in quite_good_synonyms:
+        return "Quite good"
+    if s in average_synonyms:
+        return "Average"
+    # Fallback mapping by keyword
+    if any(k in s for k in ["severe", "poor", "bad"]):
+        return "Bad"
+    if any(k in s for k in ["very good", "excellent", "good"]):
+        return "Good"
+    if any(k in s for k in ["quite", "fair", "improv", "okay", "ok", "better"]):
+        return "Quite good"
+    return "Average"
+
+
+def _extract_structured_summary(raw_text: str):
+    """Extract score, total_guess, and content from an LLM response that should be JSON."""
+    text = (raw_text or "").strip()
+    # Strip code fences if present
+    if text.startswith("```"):
+        # Remove first fence
+        text = re.sub(r"^```(?:json)?\s*", "", text)
+        # Remove ending fence
+        text = re.sub(r"```\s*$", "", text)
+        text = text.strip()
+    data = None
+    # Try direct JSON parse
+    try:
+        data = json.loads(text)
+    except Exception:
+        # Try to locate first JSON object substring
+        match = re.search(r"\{[\s\S]*\}", text)
+        if match:
+            try:
+                data = json.loads(match.group(0))
+            except Exception:
+                data = None
+    if not isinstance(data, dict):
+        data = {}
+    content = data.get("content") or data.get("summary") or raw_text
+    score_raw = data.get("score") or data.get("Score") or "Average"
+    total_guess_raw = data.get("total_guess") or data.get("Total guess") or 1
+    # Normalize total_guess
+    if isinstance(total_guess_raw, str):
+        m = re.search(r"\d+", total_guess_raw)
+        total_guess_val = int(m.group(0)) if m else 1
+    else:
+        try:
+            total_guess_val = int(total_guess_raw)
+        except Exception:
+            total_guess_val = 1
+    score_val = _normalize_score_label(score_raw)
+    return score_val, total_guess_val, content
 
 def initialize_chatbot(chat_store, container, username, user_info):
     memory = ChatMemoryBuffer.from_defaults(token_limit=3000, chat_store=chat_store, chat_store_key=username)
@@ -98,29 +181,23 @@ def chat_interface(agent, chat_store, container):
 
     if st.button("📝 Generate Mental Health Summary"):
         with st.spinner("Analyzing conversation and generating summary..."):
-            # Step 1: Let the agent generate the analysis
-            summary_prompt = "Please generate a mental health summary and diagnosis report based on this conversation."
+            # Prepare prompt asking for structured JSON only
+            username = st.session_state.get("username", "unknown_user")
+            summary_prompt = (
+                "Based on the entire conversation so far, produce a SINGLE JSON object only (no extra text, no code fences) "
+                "with the following keys: "
+                "score (one of: 'Bad', 'Average', 'Quite good', 'Good'), "
+                "total_guess (integer number of distinct conditions you considered), and "
+                "content (a concise, clear mental health summary and preliminary diagnosis)."
+            )
             summary_response = str(agent.chat(summary_prompt))
 
-            # Step 2: Fill the values
-            username = st.session_state.get("username", "unknown_user")
-            current_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-            score = "average"  # This should be parsed from summary_response
-            content = summary_response
-            total_guess = 1  # This too can be extracted from response
+            # Parse values from LLM response
+            score, total_guess, content = _extract_structured_summary(summary_response)
 
-            new_entry = {
-                "username": username,
-                "Time": current_time,
-                "Score": score,
-                "Content": content,
-                "Total guess": total_guess
-            }
+            # Persist via robust saver
+            saved_entry = save_score(score=score, content=content, total_guess=total_guess, username=username)
 
-            # ✅ Step 3: Always save to file (append line-by-line)
-            with open("data/user_storage/scores.json", "a", encoding="utf-8") as f:
-                f.write(json.dumps(new_entry, ensure_ascii=False) + "\n")
-
-            # ✅ Step 4: Show feedback
+            # Feedback
             st.success("Summary generated and saved!")
-            st.json(new_entry)
+            st.json(saved_entry)


### PR DESCRIPTION
Dynamically extract `score` and `total_guess` from LLM-generated mental health summaries and enhance score persistence.

---
<a href="https://cursor.com/background-agent?bcId=bc-647007a9-f9d9-4e35-a73e-8eb4a3acbcc6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-647007a9-f9d9-4e35-a73e-8eb4a3acbcc6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

